### PR TITLE
[Hotfix] Upgrade webpack-dev-server to version 3.1.11 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "style-ext-html-webpack-plugin": "^3.4.1",
     "style-loader": "^0.13.2",
     "webpack": "^2.6.1",
-    "webpack-dev-server": "^2.4.5"
+    "webpack-dev-server": ">=3.1.11"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## What did you implement:
Fix [webpack-dev-server vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2018-14732).

## How did you implement it:
Upgrade webpack-dev-server to version 3.1.11 or later.

## How can we verify it:
See `package.json` in root dir.