### PR TITLE
[Hotfix] Revert upgrade webpack-dev-server to version 3.1.11 or later

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "style-ext-html-webpack-plugin": "^3.4.1",
     "style-loader": "^0.13.2",
     "webpack": "^2.6.1",
-    "webpack-dev-server": ">=3.1.11"
+    "webpack-dev-server": "^2.4.5"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Because: webpack-dev-server 3.x is only compatible with webpack 4.x.